### PR TITLE
Distinguish root and non-root modules, detect non-inlined modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syn-inline-mod"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Ted Driggs <tdriggs@outlook.com>"]
 edition = "2018"
 repository = "https://github.com/TedDriggs/syn-inline-mod"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "Inlines modules in Rust source code for source analysis"
 
 [dependencies]
 syn = { version = "0.15.26", features = ["full", "visit-mut"] }
+proc-macro2 = { version = "0.4", features = ["span-locations"] }
 
 [dev-dependencies]
 quote = "0.6"

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -9,6 +9,8 @@ use crate::{FileResolver, FsResolver, ModContext};
 pub(crate) struct Visitor<'a, R: Clone> {
     /// The current file's path.
     path: &'a Path,
+    /// Whether this is the root file or not
+    root: bool,
     /// The stack of `mod` entries where the visitor is currently located. This is needed
     /// for cases where modules are declared inside inline modules.
     mod_context: ModContext,
@@ -19,17 +21,18 @@ pub(crate) struct Visitor<'a, R: Clone> {
 
 impl<'a, R: FileResolver + Default + Clone> Visitor<'a, R> {
     /// Create a new visitor with a default instance of the specified `FileResolver` type.
-    pub fn new(path: &'a Path) -> Self {
-        Self::with_resolver(path, Cow::Owned(R::default()))
+    pub fn new(path: &'a Path, root: bool) -> Self {
+        Self::with_resolver(path, root, Cow::Owned(R::default()))
     }
 }
 
 impl<'a, R: FileResolver + Clone> Visitor<'a, R> {
     /// Create a new visitor with the specified `FileResolver` instance. This will be
     /// used by all spawned visitors as we recurse down through the source code.
-    pub fn with_resolver(path: &'a Path, resolver: Cow<'a, R>) -> Self {
+    pub fn with_resolver(path: &'a Path, root: bool, resolver: Cow<'a, R>) -> Self {
         Self {
             path,
+            root,
             resolver,
             mod_context: Default::default(),
         }
@@ -56,10 +59,10 @@ impl<'a, R: FileResolver + Clone> VisitMut for Visitor<'a, R> {
             // leave the file alone.
             let file = self
                 .mod_context
-                .relative_to(self.path)
+                .relative_to(self.path, self.root)
                 .into_iter()
                 .find(|p| self.resolver.path_exists(&p))
-                .map(|path| Visitor::with_resolver(&path, self.resolver.clone()).visit());
+                .map(|path| Visitor::with_resolver(&path, false, self.resolver.clone()).visit());
 
             if let Some(syn::File { attrs, items, .. }) = file {
                 i.attrs.extend(attrs);
@@ -73,7 +76,7 @@ impl<'a, R: FileResolver + Clone> VisitMut for Visitor<'a, R> {
 
 impl<'a> From<&'a Path> for Visitor<'a, FsResolver> {
     fn from(path: &'a Path) -> Self {
-        Visitor::<FsResolver>::new(path)
+        Visitor::<FsResolver>::new(path, true)
     }
 }
 
@@ -89,7 +92,7 @@ mod tests {
     #[test]
     fn ident_in_lib() {
         let path = Path::new("./lib.rs");
-        let mut visitor = Visitor::<PathCommentResolver>::new(&path);
+        let mut visitor = Visitor::<PathCommentResolver>::new(&path, true);
         let mut file = syn::parse_file("mod c;").unwrap();
         visitor.visit_file_mut(&mut file);
         assert_eq!(
@@ -106,7 +109,7 @@ mod tests {
     #[test]
     fn path_attr() {
         let path = std::path::Path::new("./lib.rs");
-        let mut visitor = Visitor::<PathCommentResolver>::new(&path);
+        let mut visitor = Visitor::<PathCommentResolver>::new(&path, true);
         let mut file = syn::parse_file(r#"#[path = "foo/bar.rs"] mod c;"#).unwrap();
         visitor.visit_file_mut(&mut file);
         assert_eq!(

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use syn::visit_mut::VisitMut;
 use syn::ItemMod;
 
-use crate::{FileResolver, FsResolver, ModContext};
+use crate::{FileResolver, FsResolver, ModContext, SourceLocation};
 
 pub(crate) struct Visitor<'a, R: Clone> {
     /// The current file's path.
@@ -17,23 +17,26 @@ pub(crate) struct Visitor<'a, R: Clone> {
     /// The resolver that can be used to turn paths into `syn::File` instances. This removes
     /// a direct file-system dependency so the expander can be tested.
     resolver: Cow<'a, R>,
+    /// A log of module items that weren't expanded.
+    not_found_log: Option<&'a mut Vec<(String, SourceLocation)>>
 }
 
 impl<'a, R: FileResolver + Default + Clone> Visitor<'a, R> {
     /// Create a new visitor with a default instance of the specified `FileResolver` type.
-    pub fn new(path: &'a Path, root: bool) -> Self {
-        Self::with_resolver(path, root, Cow::Owned(R::default()))
+    fn new(path: &'a Path, root: bool, not_found_log: Option<&'a mut Vec<(String, SourceLocation)>>) -> Self {
+        Self::with_resolver(path, root, not_found_log, Cow::Owned(R::default()))
     }
 }
 
 impl<'a, R: FileResolver + Clone> Visitor<'a, R> {
     /// Create a new visitor with the specified `FileResolver` instance. This will be
     /// used by all spawned visitors as we recurse down through the source code.
-    pub fn with_resolver(path: &'a Path, root: bool, resolver: Cow<'a, R>) -> Self {
+    pub fn with_resolver(path: &'a Path, root: bool, not_found_log: Option<&'a mut Vec<(String, SourceLocation)>>, resolver: Cow<'a, R>) -> Self {
         Self {
             path,
             root,
             resolver,
+            not_found_log,
             mod_context: Default::default(),
         }
     }
@@ -62,11 +65,13 @@ impl<'a, R: FileResolver + Clone> VisitMut for Visitor<'a, R> {
                 .relative_to(self.path, self.root)
                 .into_iter()
                 .find(|p| self.resolver.path_exists(&p))
-                .map(|path| Visitor::with_resolver(&path, false, self.resolver.clone()).visit());
+                .map(|path| Visitor::with_resolver(&path, false, self.not_found_log.as_mut().map(|v|&mut **v), self.resolver.clone()).visit());
 
             if let Some(syn::File { attrs, items, .. }) = file {
                 i.attrs.extend(attrs);
                 i.content = Some((Default::default(), items));
+            } else if let Some(ref mut errors) = self.not_found_log {
+                errors.push((i.ident.to_string(), SourceLocation::new(self.path, i.mod_token.span)))
             }
         }
 
@@ -76,7 +81,7 @@ impl<'a, R: FileResolver + Clone> VisitMut for Visitor<'a, R> {
 
 impl<'a> From<&'a Path> for Visitor<'a, FsResolver> {
     fn from(path: &'a Path) -> Self {
-        Visitor::<FsResolver>::new(path, true)
+        Visitor::<FsResolver>::new(path, true, None)
     }
 }
 
@@ -92,7 +97,7 @@ mod tests {
     #[test]
     fn ident_in_lib() {
         let path = Path::new("./lib.rs");
-        let mut visitor = Visitor::<PathCommentResolver>::new(&path, true);
+        let mut visitor = Visitor::<PathCommentResolver>::new(&path, true, None);
         let mut file = syn::parse_file("mod c;").unwrap();
         visitor.visit_file_mut(&mut file);
         assert_eq!(
@@ -109,7 +114,7 @@ mod tests {
     #[test]
     fn path_attr() {
         let path = std::path::Path::new("./lib.rs");
-        let mut visitor = Visitor::<PathCommentResolver>::new(&path, true);
+        let mut visitor = Visitor::<PathCommentResolver>::new(&path, true, None);
         let mut file = syn::parse_file(r#"#[path = "foo/bar.rs"] mod c;"#).unwrap();
         visitor.visit_file_mut(&mut file);
         assert_eq!(


### PR DESCRIPTION
* Distinguish root and non-root modules, lib.rs and main.rs are not special
    * Add builder type to configure inlining behavior
    * This changes how resolution works for the initial file passed to `parse_and_inline_modules`, so also bumped the crate version.
* Add an option to detect non-inlined modules