### PR TITLE
Upgrades the versions of proc-macro2, quote, and syn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 description = "Inlines modules in Rust source code for source analysis"
 
 [dependencies]
-quote = "^1.0.0"
-proc-macro2 = { version = "^1.0.0", features = ["span-locations"] }
 syn = { version = "^1.0.0", features = ["full", "visit-mut"] }
+proc-macro2 = { version = "^1.0.0", features = ["span-locations"] }
+
+[dev-dependencies]
+quote = "^1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ readme = "README.md"
 description = "Inlines modules in Rust source code for source analysis"
 
 [dependencies]
-syn = { version = "0.15.26", features = ["full", "visit-mut"] }
-proc-macro2 = { version = "0.4", features = ["span-locations"] }
-
-[dev-dependencies]
-quote = "0.6"
+quote = "^1.0.0"
+proc-macro2 = { version = "^1.0.0", features = ["span-locations"] }
+syn = { version = "^1.0.0", features = ["full", "visit-mut"] }

--- a/src/mod_path.rs
+++ b/src/mod_path.rs
@@ -2,7 +2,6 @@
 
 use std::path::{Path, PathBuf};
 use syn::{Ident, ItemMod, Lit, Meta};
-use quote::ToTokens;
 
 /// Extensions to the built-in `Path` type for the purpose of mod expansion.
 trait ModPath {
@@ -124,9 +123,11 @@ impl From<&ItemMod> for ModSegment {
     fn from(v: &ItemMod) -> Self {
         for attr in &v.attrs {
             if let Ok(Meta::NameValue(name_value)) = attr.parse_meta() {
-                if name_value.path.to_token_stream().to_string() == "path" {
-                    if let Lit::Str(path_value) = name_value.lit {
-                        return ModSegment::Path(path_value.value().into());
+                if let Some(ident) = name_value.path.get_ident() {
+                    if ident.eq("path") {
+                        if let Lit::Str(path_value) = name_value.lit {
+                            return ModSegment::Path(path_value.value().into());
+                        }
                     }
                 }
             }

--- a/src/mod_path.rs
+++ b/src/mod_path.rs
@@ -2,6 +2,7 @@
 
 use std::path::{Path, PathBuf};
 use syn::{Ident, ItemMod, Lit, Meta};
+use quote::ToTokens;
 
 /// Extensions to the built-in `Path` type for the purpose of mod expansion.
 trait ModPath {
@@ -123,7 +124,7 @@ impl From<&ItemMod> for ModSegment {
     fn from(v: &ItemMod) -> Self {
         for attr in &v.attrs {
             if let Ok(Meta::NameValue(name_value)) = attr.parse_meta() {
-                if name_value.ident == "path" {
+                if name_value.path.to_token_stream().to_string() == "path" {
                     if let Lit::Str(path_value) = name_value.lit {
                         return ModSegment::Path(path_value.value().into());
                     }

--- a/src/mod_path.rs
+++ b/src/mod_path.rs
@@ -123,11 +123,9 @@ impl From<&ItemMod> for ModSegment {
     fn from(v: &ItemMod) -> Self {
         for attr in &v.attrs {
             if let Ok(Meta::NameValue(name_value)) = attr.parse_meta() {
-                if let Some(ident) = name_value.path.get_ident() {
-                    if ident.eq("path") {
-                        if let Lit::Str(path_value) = name_value.lit {
-                            return ModSegment::Path(path_value.value().into());
-                        }
+                if name_value.path.is_ident("path") {
+                    if let Lit::Str(path_value) = name_value.lit {
+                        return ModSegment::Path(path_value.value().into());
                     }
                 }
             }


### PR DESCRIPTION
I upgraded proc-macro2, quote, and syn to version use the latest versions that are semver compatible with 1.0.0. This may alleviate some of the issues people were reporting where conflicting versions of syn where being reported.

This also has the added benefit of reducing the compilation time of this crate for crates which are already depending on syn ^1.0.0.

I used the existing `cargo test` test cases to test the work. No additional tests were broken after I made the change.