### PR TITLE
Expose errors caused by invalid Rust syntax without panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.4.0 (July 8, 2020)
+- Expose errors for invalid Rust source code (#11, #13)
+
 ## v0.2.0 (June 18, 2019)
 - Distinguish root and non-root modules (#6)(https://github.com/TedDriggs/syn-inline-mod/pull/6)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "syn-inline-mod"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Ted Driggs <tdriggs@outlook.com>"]
 edition = "2018"
 repository = "https://github.com/TedDriggs/syn-inline-mod"
-documentation = "https://docs.rs/syn-inline-mod/0.3.0"
+documentation = "https://docs.rs/syn-inline-mod/0.4.0"
 license = "MIT"
 readme = "README.md"
 description = "Inlines modules in Rust source code for source analysis"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl InliningResult {
     ///
     /// # Usage
     ///
-    /// ```rust,no_run
+    /// ```rust,ignore
     /// # #![allow(unused_variables)]
     /// # use std::path::Path;
     /// # use syn_inline_mod::InlinerBuilder;
@@ -346,51 +346,46 @@ mod tests {
 
         let result = InlinerBuilder::default().parse_internal(Path::new("src/lib.rs"), env);
 
-        match result {
-            Ok(r) if r.has_errors() => {
-                let errors = &r.errors;
-                assert_eq!(errors.len(), 2, "expected 2 errors");
+        if let Ok(r) = result {
+            let errors = &r.errors;
+            assert_eq!(errors.len(), 2, "expected 2 errors");
 
-                let error = &errors[0];
-                assert_eq!(
-                    error.src_path(),
-                    Path::new("src/lib.rs"),
-                    "correct source path"
-                );
-                assert_eq!(error.module_name(), "missing");
-                assert_eq!(error.src_span().start().line, 1);
-                assert_eq!(error.src_span().start().column, 0);
-                assert_eq!(error.src_span().end().line, 1);
-                assert_eq!(error.src_span().end().column, 12);
-                assert_eq!(error.path(), Path::new("src/missing/mod.rs"));
-                let io_err = match error.kind() {
-                    Error::Io(err) => err,
-                    _ => panic!("expected ErrorKind::Io, found {}", error.kind()),
-                };
-                assert_eq!(io_err.kind(), io::ErrorKind::NotFound);
+            let error = &errors[0];
+            assert_eq!(
+                error.src_path(),
+                Path::new("src/lib.rs"),
+                "correct source path"
+            );
+            assert_eq!(error.module_name(), "missing");
+            assert_eq!(error.src_span().start().line, 1);
+            assert_eq!(error.src_span().start().column, 0);
+            assert_eq!(error.src_span().end().line, 1);
+            assert_eq!(error.src_span().end().column, 12);
+            assert_eq!(error.path(), Path::new("src/missing/mod.rs"));
+            let io_err = match error.kind() {
+                Error::Io(err) => err,
+                _ => panic!("expected ErrorKind::Io, found {}", error.kind()),
+            };
+            assert_eq!(io_err.kind(), io::ErrorKind::NotFound);
 
-                let error = &errors[1];
-                assert_eq!(
-                    error.src_path(),
-                    Path::new("src/lib.rs"),
-                    "correct source path"
-                );
-                assert_eq!(error.module_name(), "invalid");
-                assert_eq!(error.src_span().start().line, 2);
-                assert_eq!(error.src_span().start().column, 0);
-                assert_eq!(error.src_span().end().line, 2);
-                assert_eq!(error.src_span().end().column, 12);
-                assert_eq!(error.path(), Path::new("src/invalid.rs"));
-                match error.kind() {
-                    Error::Parse(_) => {}
-                    Error::Io(_) => panic!("expected ErrorKind::Parse, found {}", error.kind()),
-                }
+            let error = &errors[1];
+            assert_eq!(
+                error.src_path(),
+                Path::new("src/lib.rs"),
+                "correct source path"
+            );
+            assert_eq!(error.module_name(), "invalid");
+            assert_eq!(error.src_span().start().line, 2);
+            assert_eq!(error.src_span().start().column, 0);
+            assert_eq!(error.src_span().end().line, 2);
+            assert_eq!(error.src_span().end().column, 12);
+            assert_eq!(error.path(), Path::new("src/invalid.rs"));
+            match error.kind() {
+                Error::Parse(_) => {}
+                Error::Io(_) => panic!("expected ErrorKind::Parse, found {}", error.kind()),
             }
-            Ok(parsed) => panic!(
-                "Expected to get errors in parse/inline: {}",
-                parsed.output.into_token_stream()
-            ),
-            _ => unreachable!(),
+        } else {
+            unreachable!();
         }
     }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,4 +1,4 @@
-use crate::ErrorKind;
+use crate::Error;
 use std::path::Path;
 
 /// A resolver that can turn paths into `syn::File` instances.
@@ -9,7 +9,7 @@ pub(crate) trait FileResolver {
     /// Resolves the given path into a file.
     ///
     /// Returns an error if the file couldn't be loaded or parsed as valid Rust.
-    fn resolve(&self, path: &Path) -> Result<syn::File, ErrorKind>;
+    fn resolve(&self, path: &Path) -> Result<syn::File, Error>;
 }
 
 #[derive(Default, Clone)]
@@ -20,7 +20,7 @@ impl FileResolver for FsResolver {
         path.exists()
     }
 
-    fn resolve(&self, path: &Path) -> Result<syn::File, ErrorKind> {
+    fn resolve(&self, path: &Path) -> Result<syn::File, Error> {
         let src = std::fs::read_to_string(path)?;
         Ok(syn::parse_file(&src)?)
     }
@@ -47,7 +47,7 @@ impl FileResolver for TestResolver {
         self.files.contains_key(path)
     }
 
-    fn resolve(&self, path: &Path) -> Result<syn::File, ErrorKind> {
+    fn resolve(&self, path: &Path) -> Result<syn::File, Error> {
         let src = self.files.get(path).ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
@@ -69,7 +69,7 @@ impl FileResolver for PathCommentResolver {
         true
     }
 
-    fn resolve(&self, path: &Path) -> Result<syn::File, ErrorKind> {
+    fn resolve(&self, path: &Path) -> Result<syn::File, Error> {
         Ok(syn::parse_file(&format!(
             r#"const PATH: &str = "{}";"#,
             path.to_str().unwrap()

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,5 +1,4 @@
-use std::fs::File;
-use std::io::Read;
+use crate::ErrorKind;
 use std::path::Path;
 
 /// A resolver that can turn paths into `syn::File` instances.
@@ -7,7 +6,10 @@ pub(crate) trait FileResolver {
     /// Check if `path` exists in the backing data store.
     fn path_exists(&self, path: &Path) -> bool;
 
-    fn resolve(&self, path: &Path) -> syn::File;
+    /// Resolves the given path into a file.
+    ///
+    /// Returns an error if the file couldn't be loaded or parsed as valid Rust.
+    fn resolve(&self, path: &Path) -> Result<syn::File, ErrorKind>;
 }
 
 #[derive(Default, Clone)]
@@ -18,13 +20,9 @@ impl FileResolver for FsResolver {
         path.exists()
     }
 
-    fn resolve(&self, path: &Path) -> syn::File {
-        let mut file = File::open(&path).expect("Unable to open file");
-
-        let mut src = String::new();
-        file.read_to_string(&mut src).expect("Unable to read file");
-
-        syn::parse_file(&src).expect("Unable to parse file")
+    fn resolve(&self, path: &Path) -> Result<syn::File, ErrorKind> {
+        let src = std::fs::read_to_string(path)?;
+        Ok(syn::parse_file(&src)?)
     }
 }
 
@@ -49,17 +47,14 @@ impl FileResolver for TestResolver {
         self.files.contains_key(path)
     }
 
-    fn resolve(&self, path: &Path) -> syn::File {
-        let src = self
-            .files
-            .get(path)
-            .expect("Test should only refer to files in context");
-        syn::parse_file(src).unwrap_or_else(|_| {
-            panic!(
-                "Test code in {} should be parseable",
-                path.to_string_lossy()
+    fn resolve(&self, path: &Path) -> Result<syn::File, ErrorKind> {
+        let src = self.files.get(path).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "path not in test resolver hashmap",
             )
-        })
+        })?;
+        Ok(syn::parse_file(src)?)
     }
 }
 
@@ -74,11 +69,10 @@ impl FileResolver for PathCommentResolver {
         true
     }
 
-    fn resolve(&self, path: &Path) -> syn::File {
-        syn::parse_file(&format!(
+    fn resolve(&self, path: &Path) -> Result<syn::File, ErrorKind> {
+        Ok(syn::parse_file(&format!(
             r#"const PATH: &str = "{}";"#,
             path.to_str().unwrap()
-        ))
-        .unwrap()
+        ))?)
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use syn::visit_mut::VisitMut;
 use syn::ItemMod;
 
-use crate::{ErrorKind, FileResolver, FsResolver, InlineError, ModContext};
+use crate::{Error, FileResolver, FsResolver, InlineError, ModContext};
 
 pub(crate) struct Visitor<'a, R: Clone> {
     /// The current file's path.
@@ -46,7 +46,7 @@ impl<'a, R: FileResolver + Clone> Visitor<'a, R> {
         }
     }
 
-    pub fn visit(&mut self) -> Result<syn::File, ErrorKind> {
+    pub fn visit(&mut self) -> Result<syn::File, Error> {
         let mut syntax = self.resolver.resolve(self.path)?;
         self.visit_file_mut(&mut syntax);
         Ok(syntax)

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use syn::visit_mut::VisitMut;
 use syn::ItemMod;
 
-use crate::{FileResolver, FsResolver, ModContext, SourceLocation};
+use crate::{ErrorKind, FileResolver, FsResolver, InlineError, ModContext};
 
 pub(crate) struct Visitor<'a, R: Clone> {
     /// The current file's path.
@@ -18,17 +18,13 @@ pub(crate) struct Visitor<'a, R: Clone> {
     /// a direct file-system dependency so the expander can be tested.
     resolver: Cow<'a, R>,
     /// A log of module items that weren't expanded.
-    not_found_log: Option<&'a mut Vec<(String, SourceLocation)>>,
+    inline_error_log: Option<&'a mut Vec<InlineError>>,
 }
 
 impl<'a, R: FileResolver + Default + Clone> Visitor<'a, R> {
     /// Create a new visitor with a default instance of the specified `FileResolver` type.
-    fn new(
-        path: &'a Path,
-        root: bool,
-        not_found_log: Option<&'a mut Vec<(String, SourceLocation)>>,
-    ) -> Self {
-        Self::with_resolver(path, root, not_found_log, Cow::Owned(R::default()))
+    fn new(path: &'a Path, root: bool, inline_error_log: Option<&'a mut Vec<InlineError>>) -> Self {
+        Self::with_resolver(path, root, inline_error_log, Cow::Owned(R::default()))
     }
 }
 
@@ -38,22 +34,22 @@ impl<'a, R: FileResolver + Clone> Visitor<'a, R> {
     pub fn with_resolver(
         path: &'a Path,
         root: bool,
-        not_found_log: Option<&'a mut Vec<(String, SourceLocation)>>,
+        inline_error_log: Option<&'a mut Vec<InlineError>>,
         resolver: Cow<'a, R>,
     ) -> Self {
         Self {
             path,
             root,
             resolver,
-            not_found_log,
+            inline_error_log,
             mod_context: Default::default(),
         }
     }
 
-    pub fn visit(&mut self) -> syn::File {
-        let mut syntax = self.resolver.resolve(self.path);
+    pub fn visit(&mut self) -> Result<syn::File, ErrorKind> {
+        let mut syntax = self.resolver.resolve(self.path)?;
         self.visit_file_mut(&mut syntax);
-        syntax
+        Ok(syntax)
     }
 }
 
@@ -69,29 +65,40 @@ impl<'a, R: FileResolver + Clone> VisitMut for Visitor<'a, R> {
             // If we find a path that points to a satisfactory file, expand it
             // and replace the items with the file items. If something goes wrong,
             // leave the file alone.
-            let file = self
-                .mod_context
-                .relative_to(self.path, self.root)
-                .into_iter()
-                .find(|p| self.resolver.path_exists(&p))
-                .map(|path| {
-                    Visitor::with_resolver(
-                        &path,
-                        false,
-                        self.not_found_log.as_mut().map(|v| &mut **v),
-                        self.resolver.clone(),
-                    )
-                    .visit()
+
+            // candidates is guaranteed to be non-empty by ModContext::relative_to.
+            let candidates = self.mod_context.relative_to(self.path, self.root);
+
+            // Look for the first candidate file that exists.
+            let first_candidate = candidates
+                .iter()
+                .find(|p| self.resolver.path_exists(p))
+                .unwrap_or_else(|| {
+                    // If no candidate exists, use the last file (which will error out while
+                    // loading).
+                    candidates
+                        .iter()
+                        .last()
+                        .expect("candidates should be non-empty")
                 });
 
-            if let Some(syn::File { attrs, items, .. }) = file {
-                i.attrs.extend(attrs);
-                i.content = Some((Default::default(), items));
-            } else if let Some(ref mut errors) = self.not_found_log {
-                errors.push((
-                    i.ident.to_string(),
-                    SourceLocation::new(self.path, i.mod_token.span),
-                ))
+            let mut visitor = Visitor::with_resolver(
+                &first_candidate,
+                false,
+                self.inline_error_log.as_mut().map(|v| &mut **v),
+                self.resolver.clone(),
+            );
+
+            match visitor.visit() {
+                Ok(syn::File { attrs, items, .. }) => {
+                    i.attrs.extend(attrs);
+                    i.content = Some((Default::default(), items));
+                }
+                Err(kind) => {
+                    if let Some(ref mut errors) = self.inline_error_log {
+                        errors.push(InlineError::new(self.path, i, first_candidate, kind));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This builds on #12 to surface errors in a way that preserves the original design decisions of the crate while satisfying the use-case of #11.

cc @sunshowers