### PR TITLE
Remove hard dependency on the compiler's proc_macro crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 description = "Inlines modules in Rust source code for source analysis"
 
 [dependencies]
-syn = { version = "^1.0.0", features = ["full", "visit-mut"] }
-proc-macro2 = { version = "^1.0.0", features = ["span-locations"] }
+syn = { version = "^1.0.0", default-features = false, features = ["parsing", "printing", "full", "visit-mut"] }
+proc-macro2 = { version = "^1.0.0", default-features = false, features = ["span-locations"] }
 
 [dev-dependencies]
 quote = "^1.0.0"

--- a/src/mod_path.rs
+++ b/src/mod_path.rs
@@ -108,7 +108,7 @@ impl ModSegment {
 #[cfg(test)]
 impl ModSegment {
     pub(self) fn new_ident(ident: &'static str) -> Self {
-        ModSegment::Ident(syn::Ident::new(ident, syn::export::Span::call_site()))
+        ModSegment::Ident(syn::Ident::new(ident, proc_macro2::Span::call_site()))
     }
 
     pub(self) fn new_path(path: &'static str) -> Self {


### PR DESCRIPTION
So this is usable outside of procedural macros.

I'm using this library to write a simple bundler that can produce a single file [rust-script](https://rust-script.org) executable.