### PR TITLE
Update syn to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 description = "Inlines modules in Rust source code for source analysis"
 
 [dependencies]
-syn = { version = "^1.0.0", default-features = false, features = ["parsing", "printing", "full", "visit-mut"] }
+syn = { version = "^2.0.0", default-features = false, features = ["parsing", "printing", "full", "visit-mut"] }
 proc-macro2 = { version = "^1.0.0", default-features = false, features = ["span-locations"] }
 
 [dev-dependencies]

--- a/src/mod_path.rs
+++ b/src/mod_path.rs
@@ -1,7 +1,7 @@
 //! Path context tracking and candidate path generation for inlining.
 
 use std::path::{Path, PathBuf};
-use syn::{Ident, ItemMod, Lit, Meta};
+use syn::{Expr, ExprLit, Ident, ItemMod, Lit, Meta};
 
 /// Extensions to the built-in `Path` type for the purpose of mod expansion.
 trait ModPath {
@@ -119,9 +119,13 @@ impl ModSegment {
 impl From<&ItemMod> for ModSegment {
     fn from(v: &ItemMod) -> Self {
         for attr in &v.attrs {
-            if let Ok(Meta::NameValue(name_value)) = attr.parse_meta() {
+            if let Meta::NameValue(ref name_value) = attr.meta {
                 if name_value.path.is_ident("path") {
-                    if let Lit::Str(path_value) = name_value.lit {
+                    if let Expr::Lit(ExprLit {
+                        lit: Lit::Str(ref path_value),
+                        ..
+                    }) = name_value.value
+                    {
                         return ModSegment::Path(path_value.value().into());
                     }
                 }


### PR DESCRIPTION
Syn 2.0 has been out for a while, it mostly changes attribute parsing.

If you would like I can *probably* write this change to work on both syn 1.0 and 2.0 by writing a custom parse for the `#[path]` attribute. Thoughts?