### PR TITLE
Allow syn versions 1.x and 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 description = "Inlines modules in Rust source code for source analysis"
 
 [dependencies]
-syn = { version = "^1.0.0", default-features = false, features = ["parsing", "printing", "full", "visit-mut"] }
+# We support syn 1.x and 2.x
+syn = { version = ">=1.0.0, <3.0.0", default-features = false, features = ["parsing", "printing", "full", "visit-mut"] }
 proc-macro2 = { version = "^1.0.0", default-features = false, features = ["span-locations"] }
-
-[dev-dependencies]
 quote = "^1.0.0"


### PR DESCRIPTION
Alternative to https://github.com/TedDriggs/syn-inline-mod/pull/20

This is slightly inefficient, but given the rarity of attributes on modules it ought not be noticeable.